### PR TITLE
FIX: update response to be uploaded by db-queries and not backend

### DIFF
--- a/plio/views.py
+++ b/plio/views.py
@@ -13,13 +13,13 @@ from plio.settings import DB_QUERIES_URL
 import plio
 from users.views import get_user_config
 from components.views import get_default_config
-from utils.s3 import push_response_to_s3, get_session_id
+from utils.s3 import get_session_id
 
 URL_PREFIX_GET_PLIO = '/get_plio'
 URL_PREFIX_GET_SESSION_DATA = '/get_session_data'
 URL_PREFIX_GET_PLIO_CONFIG = '/get_plio_config'
 URL_PREFIX_GET_ALL_PLIOS = '/get_plios'	
-
+URL_PREFIX_UPDATE_RESPONSE_ENTRY = '/update_response_entry'
 
 
 @api_view(['POST'])
@@ -50,11 +50,14 @@ def update_response(request):
     # add creation date
     request.data['response']['creation_date'] = f'{datetime.now():%Y-%m-%d %H:%M:%S}'
 
-    file_path = push_response_to_s3(request.data)
+    params = { 'response': request.data['response'] }
+
+    result = requests.post(
+        DB_QUERIES_URL + URL_PREFIX_UPDATE_RESPONSE_ENTRY, json=params)
 
     return JsonResponse({
-        'path': file_path
-    }, status=200)
+        'result': result.json()
+    }, status=result.status_code)
 
 
 @api_view(['GET'])

--- a/utils/s3.py
+++ b/utils/s3.py
@@ -1,6 +1,6 @@
 from plio.settings import DB_QUERIES_URL
 from typing import Dict, List, Any
-from os.path import join, splitext, basename
+from os.path import splitext, basename
 import requests
 
 import boto3
@@ -19,32 +19,6 @@ GET_DEFAULT_USER_CONFIG_PATH = '/get_default_user_config'
 # Look in zappa_settings.json if you want to change this URL
 DB_QUERIES_URL = settings.DB_QUERIES_URL
 
-
-def push_response_to_s3(response_data: Dict):
-    """Upload response to s3"""
-    response = response_data['response']
-
-    # authenticate
-    s3 = get_resource()
-
-    # define bucket
-    bucket = DEFAULT_BUCKET
-
-    # directory where responses are saved
-    save_dir = 'answers'
-
-    # define the path where the response is saved
-    file_name = "{}_{}-{}.json".format(
-        response['plio-id'], response['user-id'],
-        response['session-id'])
-
-    # To handle windows' default backslash system
-    file_path = join(save_dir, file_name).replace("\\", "/")
-
-    s3.Object(bucket, file_path).put(
-        Body=json.dumps(response), ContentType='application/json')
-
-    return f"http://{DEFAULT_BUCKET}.s3.ap-south-1.amazonaws.com/{file_path}"
 
 
 def get_resource(


### PR DESCRIPTION
Before:
- Response JSON coming from the frontend was being passed to backend and being uploaded to S3 by the backend itself

Now:
- Response JSON coming from the frontend will be passed through backend and given to the db-queries. There it will be uploaded to S3