### PR TITLE
Move to app.plio.in

### DIFF
--- a/components/views.py
+++ b/components/views.py
@@ -3,7 +3,7 @@ from django.shortcuts import render, redirect
 from django.http import HttpResponse, HttpResponseNotFound, JsonResponse
 from django.http import response, HttpResponseBadRequest, request
 from rest_framework.decorators import api_view
-from plio.settings import DB_QUERIES_URL
+from plio.settings import DB_QUERIES_URL, FRONTEND_URL
 
 URL_PREFIX_GET_DEFAULT_COMPONENT_CONFIG = "/get_default_component_config"
 URL_PREFIX_GET_COMPONENT_FEATURES = "/get_component_features"
@@ -93,4 +93,4 @@ def get_default_config(component_type: str):
 
 
 def index(request):
-    return redirect("https://player.plio.in", permanent=True)
+    return redirect(FRONTEND_URL, permanent=True)

--- a/entries/views.py
+++ b/entries/views.py
@@ -9,7 +9,7 @@ from rest_framework.request import Request
 import pandas as pd
 from datetime import datetime
 
-from plio.settings import DB_QUERIES_URL
+from plio.settings import DB_QUERIES_URL, FRONTEND_URL
 from utils.data import convert_objects_to_df
 from utils.security import hash_function
 from utils.cleanup import is_valid_user_id
@@ -20,7 +20,7 @@ URL_PREFIX_UPDATE_ENTRY = "/update_response_entry"
 
 
 def index(request):
-    return redirect("https://player.plio.in", permanent=True)
+    return redirect(FRONTEND_URL, permanent=True)
 
 
 @api_view(["GET"])

--- a/experiments/views.py
+++ b/experiments/views.py
@@ -8,7 +8,7 @@ from django.shortcuts import redirect
 from django.http import HttpResponse, HttpResponseNotFound, JsonResponse
 from django.http import response, HttpResponseBadRequest, request
 from rest_framework.decorators import api_view
-from plio.settings import DB_QUERIES_URL
+from plio.settings import DB_QUERIES_URL, FRONTEND_URL
 from users.views import get_user_config, update_user_config
 from utils.s3 import get_default_user_config
 from utils.data import convert_objects_to_df
@@ -126,4 +126,4 @@ def fetch_all_experiments():
 
 
 def index(request):
-    return redirect("https://player.plio.in", permanent=True)
+    return redirect(FRONTEND_URL, permanent=True)

--- a/plio/settings.py
+++ b/plio/settings.py
@@ -220,3 +220,4 @@ DB_QUERIES_URL = os.environ["DB_QUERIES_URL"]
 CMS_URL = "https://cms.peerlearning.com/api"
 CMS_TOKEN = os.environ["CMS_TOKEN"]
 GET_CMS_PROBLEM_URL = "/problems"
+FRONTEND_URL = "https://app.plio.in"

--- a/plio/views.py
+++ b/plio/views.py
@@ -11,7 +11,7 @@ from rest_framework.decorators import api_view
 from rest_framework.request import Request
 from datetime import datetime
 
-from plio.settings import DB_QUERIES_URL
+from plio.settings import DB_QUERIES_URL, FRONTEND_URL
 import plio
 from components.views import get_default_config
 from users.views import get_user_config
@@ -282,9 +282,9 @@ def index(request: Request):
 
 def redirect_home(request: Request):
     """Redirect to frontend home"""
-    return redirect("https://player.plio.in", permanent=True)
+    return redirect(FRONTEND_URL, permanent=True)
 
 
 def redirect_plio(request: Request, plio_id: str):
     """Redirect to frontend plio page"""
-    return redirect(f"https://player.plio.in/#/play/{plio_id}", permanent=True)
+    return redirect(f"{FRONTEND_URL}/#/play/{plio_id}", permanent=True)

--- a/tags/views.py
+++ b/tags/views.py
@@ -5,14 +5,14 @@ from django.shortcuts import render, redirect
 from django.http import HttpResponse, HttpResponseNotFound, JsonResponse
 from rest_framework.decorators import api_view
 
-from plio.settings import DB_QUERIES_URL
+from plio.settings import DB_QUERIES_URL, FRONTEND_URL
 from utils.data import convert_objects_to_df
 
 URL_PREFIX_GET_ALL_TAGS = "/get_tags"
 
 
 def index(request):
-    return redirect("https://player.plio.in", permanent=True)
+    return redirect(FRONTEND_URL, permanent=True)
 
 
 @api_view(["GET"])

--- a/users/views.py
+++ b/users/views.py
@@ -7,7 +7,7 @@ from django.shortcuts import redirect
 from django.http import HttpResponse, HttpResponseNotFound, JsonResponse
 from django.http import response, HttpResponseBadRequest, request
 from rest_framework.decorators import api_view
-from plio.settings import DB_QUERIES_URL
+from plio.settings import DB_QUERIES_URL, FRONTEND_URL
 
 from utils.s3 import create_user_profile
 from utils.data import convert_objects_to_df
@@ -21,7 +21,7 @@ URL_PREFIX_GET_ALL_USERS = "/get_users"
 
 # Create your views here.
 def index(request):
-    return redirect("https://player.plio.in", permanent=True)
+    return redirect(FRONTEND_URL, permanent=True)
 
 
 def get_user_config(user_id):


### PR DESCRIPTION
Fixes #65 

## Summary
Changes player.plio.in to app.plio.in and made it a common param being used everywhere

## Test Plan
Tested it locally and on staging
