### PR TITLE
FIX: changed lookup for plio to uuid

### DIFF
--- a/plio/views.py
+++ b/plio/views.py
@@ -330,6 +330,7 @@ class PlioViewSet(viewsets.ModelViewSet):
 
     queryset = Plio.objects.all()
     serializer_class = PlioSerializer
+    lookup_field = "uuid"
 
 
 class ItemViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
Fixes #78
 
## Summary
Changed the lookup_field of PlioViewSet to use UUID for fetching instead of primary key

## Test Plan
Tested locally on postman - the API docs also reflect the change.