### PR TITLE
FIX: added question details in item serializer + some cleanups

### DIFF
--- a/plio/models.py
+++ b/plio/models.py
@@ -81,7 +81,7 @@ class Item(SafeDeleteModel):
         db_table = "item"
 
     def __str__(self):
-        return "%d: %s - %s" % (self.id, self.plio.name, self.text)
+        return "%d: %s - %s" % (self.id, self.plio.name, self.type)
 
 
 class Question(SafeDeleteModel):

--- a/plio/serializers.py
+++ b/plio/serializers.py
@@ -56,7 +56,11 @@ class ItemSerializer(serializers.ModelSerializer):
 
     def to_representation(self, instance):
         response = super().to_representation(instance)
-        response["plio"] = PlioSerializer(instance.plio).data
+        if instance.type == "question":
+            # add the question details to the item response
+            response["details"] = QuestionSerializer(
+                instance.question_set.all()[0]
+            ).data
         return response
 
 
@@ -72,8 +76,3 @@ class QuestionSerializer(serializers.ModelSerializer):
             "created_at",
             "updated_at",
         ]
-
-    def to_representation(self, instance):
-        response = super().to_representation(instance)
-        response["item"] = ItemSerializer(instance.item).data
-        return response


### PR DESCRIPTION
Fixes #84 

## Summary
- [x] Updates the ItemSerializer to load Question details using QuestionSerializer when the item type is Question
- [x] addresses a bug where self.text was being used in Item even after text was removed from its model
- [x] removes to_representation in Question 

## Test Plan
Tested locally with postman
