### PR TITLE
User access to org level plios

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,4 +20,4 @@ repos:
         # these are errors that will be ignored by flake8
         # check out their meaning here
         # https://flake8.pycqa.org/en/latest/user/error-codes.html
-        - "--ignore=E501,E203"
+        - "--ignore=E501,E203,W503"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ services: # the different images that will be running as containers
       - postgres_data:/var/lib/postgresql/data/
     restart: "on-failure"
   web: # service name
+    stdin_open: true
+    tty: true
     build: . # build the image for the web service from the dockerfile in parent directory.
     volumes:
       - .:/app # map data and files from parent directory in host to plio directory in docker container

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services: # the different images that will be running as containers
       - postgres_data:/var/lib/postgresql/data/
     restart: "on-failure"
   web: # service name
+    # allows one to attach the terminal of a running container for debugging
     stdin_open: true
     tty: true
     build: . # build the image for the web service from the dockerfile in parent directory.

--- a/organizations/admin.py
+++ b/organizations/admin.py
@@ -1,1 +1,5 @@
-# Register your models here.
+from django.contrib import admin
+from .models import Organization, Domain
+
+admin.site.register(Organization)
+admin.site.register(Domain)

--- a/organizations/middleware.py
+++ b/organizations/middleware.py
@@ -8,13 +8,17 @@ class OrganizationTenantMiddleware(TenantMainMiddleware):
     Sets connection to either public or tenant schema based on `ORGANIZATION` HTTP header value.
     """
 
+    def get_organization_shortcode(self, request):
+        """
+        Returns the value of the `ORGANIZATION` HTTP header
+        """
+        return request.META.get("HTTP_ORGANIZATION", get_public_schema_name())
+
     def get_tenant(self, tenant_model, request):
         """
         Determines tenant by the value of the `ORGANIZATION` HTTP header.
         """
-        organization_shortcode = request.META.get(
-            "HTTP_ORGANIZATION", get_public_schema_name()
-        )
+        organization_shortcode = self.get_organization_shortcode(request)
         return tenant_model.objects.filter(shortcode=organization_shortcode).first()
 
     def process_request(self, request):

--- a/organizations/middleware.py
+++ b/organizations/middleware.py
@@ -8,7 +8,8 @@ class OrganizationTenantMiddleware(TenantMainMiddleware):
     Sets connection to either public or tenant schema based on `ORGANIZATION` HTTP header value.
     """
 
-    def get_organization_shortcode(self, request):
+    @staticmethod
+    def get_organization(request):
         """
         Returns the value of the `ORGANIZATION` HTTP header
         """
@@ -18,7 +19,7 @@ class OrganizationTenantMiddleware(TenantMainMiddleware):
         """
         Determines tenant by the value of the `ORGANIZATION` HTTP header.
         """
-        organization_shortcode = self.get_organization_shortcode(request)
+        organization_shortcode = self.get_organization(request)
         return tenant_model.objects.filter(shortcode=organization_shortcode).first()
 
     def process_request(self, request):


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/avantifellows/plio-backend) and create your branch from `master`.
  2. Run the installation steps from the project's [README.md](https://github.com/avantifellows/plio-backend#readme).
  3. Please ensure coding standard and conventions are followed. You can find the details at https://docs.djangoproject.com/en/dev/internals/contributing/writing-code/coding-style/.
  4. Ensure that an issue has been created for the problem this PR attempts to solve and your Pull Request is linked to the issue. Read more how to link PR to an issue at https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue.

-->

Fixes #144

## Summary
- [x] A user who belongs to an org, should be able to view/play/edit/delete all the PUBLIC plios that are created by other users of the org.

- [x] A user who belongs to an org, should NOT be able to view/play/edit/delete the PRIVATE plios that are created by other users of the org.

- [x] A user who DOES NOT belong to an org, should not be able to access those org's plios - through frontend or through the API

- [x] A user, who is NOT the original creator of the plio, should be able to edit the plio, but the `created_by` field in that plio should still be equal to the original user who was the original creator of the plio
- [x] Allow std input and allow a docker container to be attached to the terminal - for debugging purposes
