### PR TITLE
Support for AWS Cognito

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,11 +40,12 @@ DEFAULT_TENANT_NAME=Plio
 DEFAULT_TENANT_SHORTCODE=plio
 DEFAULT_TENANT_DOMAIN=0.0.0.0
 
-# Auth0 settings
-AUTH0_TOKEN_URL=
-AUTH0_CLIENT_ID=
-AUTH0_CLIENT_SECRET=
-AUTH0_AUDIENCE=
+# Analytics Identity Provider (IDP) configurations
+ANALYTICS_IDP_TYPE= # possible values are `cognito` or `auth0`
+ANALYTICS_IDP_TOKEN_URL=
+ANALYTICS_IDP_CLIENT_ID=
+ANALYTICS_IDP_CLIENT_SECRET=
+ANALYTICS_IDP_AUDIENCE= # not needed when IDP is `cognito`
 
 # email settings
 EMAIL_BACKEND='django.core.mail.backends.smtp.EmailBackend'

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -101,17 +101,28 @@ Shortcode for the default tenant (e.g. plio)
 The domain for the default tenant (e.g. 0.0.0.0 locally, plio.in on production)
 
 
-### Auth0 for Plio Analytics
-While setting up Plio analytics, you need to make sure the following variables are also updated. These are responsible to fetch an access token from Auth0 Identity Provider.
+### Identity Provider for Plio Analytics
+While setting up Plio analytics, you need to make sure the following variables are also updated. These are responsible to fetch an access token from the configured Identity Provider.
 
-#### `AUTH0_TOKEN_URL`
-The url to request access token from Auth0. Generally looks like `https://<AUTH0-SUBDOMAIN>.auth0.com/oauth/token`
+#### `ANALYTICS_IDP_TYPE`
+Plio Analytics supports two identity providers. The possible values for this variable are `cognito` (AWS Cognito) and `auth0` (Auth0).
 
-#### `AUTH0_CLIENT_ID`
-The client id for your Auth0 app. Retrieve from Auth0 Application settings page
+#### `ANALYTICS_IDP_TOKEN_URL`
+The url to request access token from the Identity Provider. Generally looks like:
+1. When type is `cognito`: `https://<APP-DOMAIN-PREFIX>.auth.<aws-region>.amazoncognito.com/oauth2/token`. This is the same as the Amazon Cognito domain you have configured.
+2. When type is `auth0`: `https://<AUTH0-SUBDOMAIN>.auth0.com/oauth/token`
 
-#### `AUTH0_CLIENT_SECRET`
-The client secret for your Auth0 app. Retrieve from Auth0 Application settings page
+#### `ANALYTICS_IDP_CLIENT_ID`
+The client id for your identity provider app.
+1. When type is `cognito`: Retrieve this from your User pool's "App clients" page.
+2. When type is `auth0`: Retrieve from Auth0 Application settings page.
 
-#### `AUTH0_AUDIENCE`
-Unique Identifier for your Auth0 API. Retrieve from Auth0 API settings.
+#### `ANALYTICS_IDP_CLIENT_SECRET`
+The client secret for your identity provider app.
+1. When type is `cognito`: Retrieve this from your User pool's "App clients" page.
+2. When type is `auth0`: Retrieve from Auth0 Application settings page.
+
+#### `ANALYTICS_IDP_AUDIENCE`
+Unique Identifier for your Auth0 API.
+1. When type is `cognito`: Not needed.
+2. When type is `auth0`: Retrieve from Auth0 API settings.

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -110,7 +110,7 @@ Plio Analytics supports two identity providers. The possible values for this var
 #### `ANALYTICS_IDP_TOKEN_URL`
 The url to request access token from the Identity Provider. Generally looks like:
 1. When type is `cognito`: `https://<APP-DOMAIN-PREFIX>.auth.<aws-region>.amazoncognito.com/oauth2/token`. This is the same as the Amazon Cognito domain you have configured.
-2. When type is `auth0`: `https://<AUTH0-SUBDOMAIN>.auth0.com/oauth/token`
+2. When type is `auth0`: `https://<AUTH0-SUBDOMAIN>.<REGION>.auth0.com/oauth/token`
 
 #### `ANALYTICS_IDP_CLIENT_ID`
 The client id for your identity provider app.

--- a/plio/settings.py
+++ b/plio/settings.py
@@ -292,10 +292,13 @@ CHANNEL_LAYERS = {
 }
 
 # authentication
-AUTH0_TOKEN_URL = os.environ.get("AUTH0_TOKEN_URL")
-AUTH0_CLIENT_ID = os.environ.get("AUTH0_CLIENT_ID")
-AUTH0_CLIENT_SECRET = os.environ.get("AUTH0_CLIENT_SECRET")
-AUTH0_AUDIENCE = os.environ.get("AUTH0_AUDIENCE")
+ANALYTICS_IDP = {
+    "type": os.environ.get("ANALYTICS_IDP_TYPE"),
+    "token_url": os.environ.get("ANALYTICS_IDP_TOKEN_URL"),
+    "client_id": os.environ.get("ANALYTICS_IDP_CLIENT_ID"),
+    "client_secret": os.environ.get("ANALYTICS_IDP_CLIENT_SECRET"),
+    "audience": os.environ.get("ANALYTICS_IDP_AUDIENCE", ""),
+}
 
 # email
 EMAIL_BACKEND = os.environ.get("EMAIL_BACKEND")

--- a/users/views.py
+++ b/users/views.py
@@ -227,7 +227,7 @@ def update_organization_user(sender, instance: OrganizationUser, **kwargs):
 
 @api_view(["POST"])
 def retrieve_analytics_app_access_token(request):
-    """Makes a client_credentials request to the configured identity provider to retrieve an access token."""
+    """Requests the configured identity provider to retrieve an access token."""
 
     payload = {
         "grant_type": "client_credentials",

--- a/users/views.py
+++ b/users/views.py
@@ -20,11 +20,8 @@ from plio.settings import (
     API_APPLICATION_NAME,
     OAUTH2_PROVIDER,
     OTP_EXPIRE_SECONDS,
-    AUTH0_TOKEN_URL,
-    AUTH0_CLIENT_ID,
-    AUTH0_CLIENT_SECRET,
-    AUTH0_AUDIENCE,
     DEFAULT_FROM_EMAIL,
+    ANALYTICS_IDP,
 )
 
 from users.models import User, OneTimePassword, OrganizationUser
@@ -230,12 +227,15 @@ def update_organization_user(sender, instance: OrganizationUser, **kwargs):
 
 @api_view(["POST"])
 def retrieve_analytics_app_access_token(request):
-    """Makes a client_credentials request to Auth0 app to get an access token."""
+    """Makes a client_credentials request to the configured identity provider to retrive an access token."""
+
     payload = {
         "grant_type": "client_credentials",
-        "client_id": AUTH0_CLIENT_ID,
-        "client_secret": AUTH0_CLIENT_SECRET,
-        "audience": AUTH0_AUDIENCE,
+        "client_id": ANALYTICS_IDP["client_id"],
+        "client_secret": ANALYTICS_IDP["client_secret"],
     }
-    response = requests.post(AUTH0_TOKEN_URL, data=payload)
+    if ANALYTICS_IDP["type"] == "auth0":
+        payload.audience = ANALYTICS_IDP["audience"]
+
+    response = requests.post(ANALYTICS_IDP["token_url"], data=payload)
     return Response(response.json(), status=status.HTTP_200_OK)

--- a/users/views.py
+++ b/users/views.py
@@ -235,7 +235,7 @@ def retrieve_analytics_app_access_token(request):
         "client_secret": ANALYTICS_IDP["client_secret"],
     }
     if ANALYTICS_IDP["type"] == "auth0":
-        payload.audience = ANALYTICS_IDP["audience"]
+        payload["audience"] = ANALYTICS_IDP["audience"]
 
     response = requests.post(ANALYTICS_IDP["token_url"], data=payload)
     return Response(response.json(), status=status.HTTP_200_OK)

--- a/users/views.py
+++ b/users/views.py
@@ -227,7 +227,7 @@ def update_organization_user(sender, instance: OrganizationUser, **kwargs):
 
 @api_view(["POST"])
 def retrieve_analytics_app_access_token(request):
-    """Makes a client_credentials request to the configured identity provider to retrive an access token."""
+    """Makes a client_credentials request to the configured identity provider to retrieve an access token."""
 
     payload = {
         "grant_type": "client_credentials",


### PR DESCRIPTION
## Summary

1. Generalized the Identity Provider code and documentation.
2. Plio now supports both Auth0 and AWS Cognito.

## Test Plan

Tested locally with cubejs dev mode false. Needs more hands on testing.

- [ ] test it on staging
- [ ] test it on production