### PR TITLE
checks whether correct params for mobile have been passed during OTP request

### DIFF
--- a/users/tests.py
+++ b/users/tests.py
@@ -11,17 +11,16 @@ from plio.tests import BaseTestCase
 from plio.cache import get_cache_key
 
 
-class OtpAuthTestCase(BaseTestCase):  
+class OtpAuthTestCase(BaseTestCase):
     """Tests the OTP functionality."""
 
     def setUp(self):
         super().setUp()
         # unset client credentials token so that the subsequent API calls goes as guest
         self.client.credentials()
+
     def test_request_otp_mobile_not_passed(self):
-        response = self.client.post(
-            reverse("request-otp")
-        )
+        response = self.client.post(reverse("request-otp"))
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_guest_can_request_for_otp(self):

--- a/users/tests.py
+++ b/users/tests.py
@@ -22,7 +22,7 @@ class OtpAuthTestCase(BaseTestCase):
     def test_requesting_otp_fails_when_mobile_not_passed(self):
         response = self.client.post(reverse("request-otp"))
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(response.data["detail"], "Mobile Not Provided")
+        self.assertEqual(response.data["detail"], "mobile not provided")
 
     def test_guest_can_request_for_otp(self):
         response = self.client.post(

--- a/users/tests.py
+++ b/users/tests.py
@@ -19,16 +19,16 @@ class OtpAuthTestCase(BaseTestCase):
         # unset client credentials token so that the subsequent API calls goes as guest
         self.client.credentials()
 
-    def test_request_otp_mobile_not_passed(self):
+    def test_requesting_otp_fails_when_mobile_not_passed(self):
         response = self.client.post(reverse("request-otp"))
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["detail"], "Mobile Not Provided")
 
     def test_guest_can_request_for_otp(self):
         response = self.client.post(
             reverse("request-otp"), {"mobile": self.user.mobile}
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-
         otp_exists = OneTimePassword.objects.filter(mobile=self.user.mobile).exists()
         self.assertTrue(otp_exists)
 

--- a/users/tests.py
+++ b/users/tests.py
@@ -11,13 +11,18 @@ from plio.tests import BaseTestCase
 from plio.cache import get_cache_key
 
 
-class OtpAuthTestCase(BaseTestCase):
+class OtpAuthTestCase(BaseTestCase):  
     """Tests the OTP functionality."""
 
     def setUp(self):
         super().setUp()
         # unset client credentials token so that the subsequent API calls goes as guest
         self.client.credentials()
+    def test_request_otp_mobile_not_passed(self):
+        response = self.client.post(
+            reverse("request-otp")
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_guest_can_request_for_otp(self):
         response = self.client.post(

--- a/users/views.py
+++ b/users/views.py
@@ -162,6 +162,11 @@ def get_new_access_token(user, application):
 @permission_classes([AllowAny])
 def request_otp(request):
     otp = OneTimePassword()
+    if "mobile" not in request.data:
+        return Response(
+            {"detail": "mobile not provided"},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
     otp.mobile = request.data["mobile"]
     otp.otp = random.randint(100000, 999999)
     otp.expires_at = timezone.now() + datetime.timedelta(seconds=OTP_EXPIRE_SECONDS)


### PR DESCRIPTION
Fixes #300

## Summary
Checks whether correct params have been passed during OTP request 

Tests are written for testing whether the correct params(mobile) have been passed while requesting otp. 

## Test Plan

- [x] Wrote tests
- [x] Tested locally
- [ ] Tested on staging
- [ ] Tested on production
- [ ] ~If adding any new environment variable:~
    - [ ] update `docs/ENV.md`
    - [ ] update the environment variables for staging and production
- [ ] ~If changes in DB, update [DB schema](https://docs.google.com/presentation/d/15c45HbHphh4w3guaFV3BgEA5nMKd-4J35JdUKdrpPzo/edit#slide=id.gc8c9ec0b5e_0_0) and BigQuery (staging and prod)~
