### PR TITLE
fix #47: after pip install update requirement.txt

### DIFF
--- a/plio/settings.py
+++ b/plio/settings.py
@@ -14,6 +14,10 @@ import os
 import logging
 from corsheaders.defaults import default_headers
 
+# Load environment variables from .env file
+from dotenv import load_dotenv
+load_dotenv()
+
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,33 @@
+# Django Project Package Management
+
+This directory contains scripts to help manage Python packages in this Django project.
+
+## Usage
+
+### Windows (PowerShell or Command Prompt)
+
+Use `scripts\pip.bat` instead of `pip`:
+
+```
+scripts\pip install package_name
+```
+
+This will:
+1. Install the package normally
+2. Automatically update requirements.txt with the package and version
+
+### For other pip commands
+
+Any other pip commands work as normal:
+
+```
+scripts\pip list
+scripts\pip freeze
+scripts\pip uninstall package_name
+```
+
+## Important Notes
+
+- Always use `scripts\pip install` instead of regular `pip install` to keep requirements.txt up to date
+- These scripts must be run from the project root directory
+- Share this setup with all team members to ensure consistent package management

--- a/scripts/pip-install.sh
+++ b/scripts/pip-install.sh
@@ -1,0 +1,40 @@
+# This script is a wrapper for pip install that updates requirements.txt
+# with the installed package versions. It checks if the package is already
+# listed in requirements.txt and updates the version if necessary.
+# It also handles the case where pip install fails, ensuring that
+# requirements.txt is not modified in that case.
+# This script is a wrapper for pip install that updates requirements.txt
+#!/bin/bash
+
+# Only proceed if the first argument is "install"
+if [[ "$1" == "install" ]]; then
+    shift  # Remove the "install" from arguments
+
+    # Install packages
+    pip install "$@"
+
+    # If pip install was successful, update requirements.txt
+    if [[ $? -eq 0 ]]; then
+        for pkg in "$@"; do
+            pkg_name=$(echo "$pkg" | cut -d'=' -f1 | cut -d'[' -f1)
+            version=$(pip show "$pkg_name" 2>/dev/null | grep Version | awk '{print $2}')
+            line="${pkg_name}==${version}"
+
+            # Check if the package is already in requirements.txt
+            if grep -q "^$pkg_name==" requirements.txt; then
+                # Replace the old version with the new one using a temporary file
+                awk -v pkg="$pkg_name" -v line="$line" '{if ($1 ~ "^" pkg"==") print line; else print $0}' requirements.txt > temp.txt && mv temp.txt requirements.txt
+                echo "✅ Updated $pkg_name to $line in requirements.txt"
+            else
+                # If it doesn't exist, add it
+                echo "$line" >> requirements.txt
+                echo "✅ Added $line to requirements.txt"
+            fi
+        done
+    else
+        echo "❌ Package installation failed. No changes made to requirements.txt."
+    fi
+else
+    # Fallback to regular pip
+    pip "$@"
+fi

--- a/scripts/pip.bat
+++ b/scripts/pip.bat
@@ -1,0 +1,2 @@
+@echo off
+powershell -ExecutionPolicy Bypass -File "%~dp0pip.ps1" %*

--- a/scripts/pip.ps1
+++ b/scripts/pip.ps1
@@ -1,0 +1,84 @@
+# Custom pip wrapper script for Django project
+# This overrides pip install to update requirements.txt
+
+param (
+    [Parameter(ValueFromRemainingArguments=$true)]
+    [string[]]$Arguments
+)
+
+# Check if the command is "install"
+if ($Arguments.Length -gt 0 -and $Arguments[0] -eq "install") {
+    # Store the package arguments (everything after "install")
+    $packageArgs = $Arguments[1..$Arguments.Length]
+    
+    Write-Host "Installing packages: $packageArgs" -ForegroundColor Cyan
+    
+    # Run the actual pip install command
+    python -m pip install $packageArgs
+    
+    # Only update requirements.txt if the installation was successful
+    if ($LASTEXITCODE -eq 0) {
+        foreach ($pkg in $packageArgs) {
+            # Extract package name (removing version specifiers or extras)
+            if ($pkg -match "^([a-zA-Z0-9\-_.]+)") {
+                $pkgName = $Matches[1]
+                
+                Write-Host "Processing package: $pkgName" -ForegroundColor Cyan
+                
+                # Get the installed version
+                $versionInfo = python -m pip show $pkgName | Select-String "Version:"
+                
+                if ($versionInfo) {
+                    $version = ($versionInfo -split "Version:")[1].Trim()
+                    $line = "${pkgName}==${version}"
+                    
+                    Write-Host "Package version: $version" -ForegroundColor Cyan
+                    
+                    # Check if requirements.txt exists
+                    # $requirementsPath = Join-Path $PSScriptRoot ".." "requirements.txt"
+                    # Combine to get the full path to requirements.txt (one level up from script folder)
+                    $requirementsPath = Join-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath "..") -ChildPath "requirements.txt"
+
+                    if (Test-Path $requirementsPath) {
+                        $requirementsContent = Get-Content $requirementsPath
+                        $updatedContent = @()
+                        $packageFound = $false
+                        
+                        # Check line by line and update if package exists
+                        foreach ($contentLine in $requirementsContent) {
+                            if ($contentLine -match "^$pkgName==") {
+                                $updatedContent += $line
+                                $packageFound = $true
+                                Write-Host "✅ Updated $pkgName to version $version in requirements.txt" -ForegroundColor Green
+                            } else {
+                                $updatedContent += $contentLine
+                            }
+                        }
+                        
+                        # If package wasn't found in the file, add it
+                        if (-not $packageFound) {
+                            $updatedContent += $line
+                            Write-Host "✅ Added $line to requirements.txt" -ForegroundColor Green
+                        }
+                        
+                        # Write the updated content back to file
+                        $updatedContent | Set-Content $requirementsPath -Force
+                    } else {
+                        # Create requirements.txt if it doesn't exist
+                        $line | Set-Content $requirementsPath -Force
+                        Write-Host "✅ Created requirements.txt with $line" -ForegroundColor Green
+                    }
+                } else {
+                    Write-Host "⚠️ Could not determine version for $pkgName" -ForegroundColor Yellow
+                }
+            } else {
+                Write-Host "⚠️ Could not parse package name from $pkg" -ForegroundColor Yellow
+            }
+        }
+    } else {
+        Write-Host "❌ Package installation failed. No changes made to requirements.txt." -ForegroundColor Red
+    }
+} else {
+    # For non-install commands, just pass through to pip
+    python -m pip $Arguments
+}


### PR DESCRIPTION
step 1: setup the project in local machine.
step 2: check it. project setup is correct by running it.
step 3:  create scripts folder and add this three files. 
          1. pip.ps1
          2. pip.bat
          3. pip-install.sh
which created in this PR. this file capable of update requirements.txt when packages are installed successfully.
for this in the **terminal**  set this .
        1.  for windows - set alias like : Set-Alias -Name pip -Value "$PWD\scripts\pip.ps1"
        or 
         1.  for linux - set alias like : alias pip="$PWD/scripts/pip-install.sh"
         
after this alias set up 
  when you install packages through " pip install <package> " it will add the " package name== package version" in the requirements.txt file. 

if you not set the alias - you should run like "scripts\pip install package_name"(windows) and for linux "scripts\pip-install install package_name " for installing packages. then this will update the requirements.txt