### PR TITLE
chore: add mex agent memory scaffold (AGENTS.md + .mex/)

### DIFF
--- a/.mex/AGENTS.md
+++ b/.mex/AGENTS.md
@@ -1,0 +1,34 @@
+---
+name: agents
+description: Always-loaded project anchor. Read this first. Contains project identity, non-negotiables, commands, and pointer to ROUTER.md for full context.
+last_updated: 2026-07-11
+---
+
+# Plio Backend
+
+## What This Is
+Multi-tenant Django REST API powering Plio — interactive video lessons: creators build plios (video + timed questions), learners watch and answer; every workspace is an isolated Postgres schema.
+
+## Non-Negotiables
+- Respect tenancy on every data access — the `Organization` request header selects the Postgres schema (django-tenants); never query across schemas without an explicit schema switch
+- Deletes are soft deletes (django-safedelete) everywhere — never hard-delete rows or write raw SQL deletes
+- Invalidate the Redis cache through the helpers in `plio/cache.py` whenever a cached entity mutates — keys are tenant-scoped
+- Never commit secrets — `.env` is gitignored; document new vars in `.env.example` and `docs/ENV.md`
+- Never edit an applied migration; new models must be placed correctly in SHARED_APPS vs TENANT_APPS in `plio/settings.py`
+
+## Commands
+- Run (docker): `docker-compose up -d --build` — API at http://0.0.0.0:8001/api/v1, admin at /admin
+- Test: `docker-compose exec web python manage.py test` (CI runs `coverage run manage.py test`)
+- Lint: `pre-commit run --all-files` (black + flake8)
+- Migrations: `docker-compose exec web python manage.py makemigrations` / `migrate`
+
+## Scaffold Growth
+After meaningful work, run GROW:
+- Ground: what changed in reality?
+- Record: update `ROUTER.md` and relevant `context/` files
+- Orient: create or update a `patterns/` runbook if this can recur
+- Write: bump `last_updated` on changed scaffold files and run `mex log` when rationale matters
+
+## Navigation
+At the start of every session, read `ROUTER.md` before doing anything else.
+For full project context, patterns, and task guidance — everything is there.

--- a/.mex/ROUTER.md
+++ b/.mex/ROUTER.md
@@ -1,0 +1,68 @@
+---
+name: router
+description: Session bootstrap and navigation hub. Read at the start of every session before any task. Contains project state, routing table, and behavioural contract.
+edges:
+  - target: context/architecture.md
+    condition: when working on system design, integrations, or understanding how components connect
+  - target: context/stack.md
+    condition: when working with specific technologies, libraries, or making tech decisions
+  - target: context/conventions.md
+    condition: when writing new code, reviewing code, or unsure about project patterns
+  - target: context/decisions.md
+    condition: when making architectural choices or understanding why something is built a certain way
+  - target: context/setup.md
+    condition: when setting up the dev environment or running the project for the first time
+  - target: patterns/INDEX.md
+    condition: when starting a task — check the pattern index for a matching pattern file
+last_updated: 2026-07-11
+---
+
+# Session Bootstrap
+
+If you haven't already read `AGENTS.md`, read it now — it contains the project identity, non-negotiables, and commands.
+
+Then read this file fully before doing anything else in this session.
+
+## Current Project State
+
+**Working:**
+- Full REST API (v1): plios, items, questions, videos, images, sessions, session-answers, events, users, organizations, experiments, tags — standard DRF CRUD plus plio actions (play, duplicate, copy, metrics, download_data)
+- Three auth flows: Google OAuth (convert-token), OTP over SMS (AWS SNS), and third-party SSO (org api_key + unique_id)
+- Schema-per-workspace multi-tenancy, Redis caching with tenant-scoped keys, soft delete everywhere, live user updates over WebSocket (channels)
+- ~260 unit tests across users, organizations, entries, and plio apps (CI: coverage + Codecov)
+
+**Not yet built:**
+- Django upgrade: master still runs Django 3.1.1 — an unmerged PR chain (#354–#360, branches ralph/django-*-migration) steps 3.1 → 5.2.14 LTS
+- API/integration tests that follow real user journeys (creator: create→publish; learner: session→answers) — unit tests cover isolated CRUD only; a grilling/scoping session for this was started May 2026 but never finished
+- experiments and tags apps have placeholder tests; events, session-answers, images have minimal coverage
+
+**Known issues:**
+- Several dependencies are years behind (see requirements.txt pins) until the migration chain merges — don't add code relying on newer Django/DRF APIs on master
+- django-request-logging is abandoned upstream; replacement deferred to its own PR (post-migration)
+
+## Routing Table
+
+Load the relevant file based on the current task. Always load `context/architecture.md` first if not already in context this session.
+
+| Task type | Load |
+|-----------|------|
+| Understanding how the system works | `context/architecture.md` |
+| Working with a specific technology | `context/stack.md` |
+| Writing or reviewing code | `context/conventions.md` |
+| Making a design decision | `context/decisions.md` |
+| Setting up or running the project | `context/setup.md` |
+| Any specific task | Check `patterns/INDEX.md` for a matching pattern |
+
+## Behavioural Contract
+
+For every task, follow this loop:
+
+1. **CONTEXT** — Load the relevant context file(s) from the routing table above. Check `patterns/INDEX.md` for a matching pattern. If one exists, follow it. Narrate what you load: "Loading architecture context..."
+2. **BUILD** — Do the work. If a pattern exists, follow its Steps. If you are about to deviate from an established pattern, say so before writing any code — state the deviation and why.
+3. **VERIFY** — Load `context/conventions.md` and run the Verify Checklist item by item. State each item and whether the output passes. Do not summarise — enumerate explicitly.
+4. **DEBUG** — If verification fails or something breaks, check `patterns/INDEX.md` for a debug pattern. Follow it. Fix the issue and re-run VERIFY.
+5. **GROW** — After meaningful work, run this binary checklist:
+   - **Ground:** What changed in reality? Name the changed behavior, system, command, dependency, or workflow.
+   - **Record:** If project state changed, update the "Current Project State" section above. If documented facts changed, update the relevant `context/` file surgically.
+   - **Orient:** If this task can recur and no pattern exists, create one in `patterns/` using `patterns/README.md`, then add it to `patterns/INDEX.md`. If a pattern exists but you learned a gotcha, update it.
+   - **Write:** Bump `last_updated` in every scaffold file you changed. If the why matters, run `mex log --type decision "<what changed and why>"` or `mex log "<note>"`.

--- a/.mex/SETUP.md
+++ b/.mex/SETUP.md
@@ -1,0 +1,228 @@
+# Setup — Populate This Scaffold
+
+This file contains the prompts to populate the scaffold. It is NOT the dev environment setup — for that, see `context/setup.md` after population.
+
+This scaffold is currently empty. Follow the steps below to populate it for your project.
+
+## Recommended: Use setup.sh
+
+```bash
+.mex/setup.sh
+```
+
+The script handles everything automatically:
+1. Detects your project state (existing codebase, fresh project, or partial)
+2. Asks which AI tool you use and copies the right config file
+3. Pre-scans your codebase with `mex init` to build a structured brief (~5-8k tokens vs ~50k from AI exploration)
+4. Builds and runs the population prompt — or prints it for manual paste
+
+If you want to populate manually instead, use the prompts below.
+
+## Detecting Your State
+
+**Existing codebase?** Follow Option A.
+**Fresh project, nothing built yet?** Follow Option B.
+**Partially built?** Follow Option A — the agent will flag empty slots it cannot fill yet.
+
+---
+
+## Option A — Existing Codebase
+
+Paste the following prompt into your agent:
+
+---
+
+**SETUP PROMPT — copy everything between the lines:**
+
+```
+You are going to populate an AI context scaffold for this project.
+The scaffold lives in the root of this repository.
+
+Read the following files in order before doing anything else:
+1. ROUTER.md — understand the scaffold structure
+2. context/architecture.md — read the annotation comments to understand what belongs there
+3. context/stack.md — same
+4. context/conventions.md — same
+5. context/decisions.md — same
+6. context/setup.md — same
+
+Then explore this codebase:
+- Read the main entry point(s)
+- Read the folder structure
+- Read 2-3 representative files from each major layer
+- Read any existing README or documentation
+
+PASS 1 — Populate knowledge files:
+
+Populate each context/ file by replacing the annotation comments
+with real content from this codebase. Follow the annotation instructions exactly.
+For each slot:
+- Use the actual names, patterns, and structures from this codebase
+- Do not use generic examples
+- Do not leave any slot empty — if you cannot determine the answer,
+  write "[TO DETERMINE]" and explain what information is needed
+- Keep length within the guidance given in each annotation
+
+Then assess: does this project have domains complex enough that cramming
+them into architecture.md would make it too long or too shallow?
+If yes, create additional domain-specific context files in context/.
+Examples: a project with a complex auth system gets context/auth.md.
+A data pipeline gets context/ingestion.md. A project with Stripe gets
+context/payments.md. Use the same YAML frontmatter format (name,
+description, triggers, edges, last_updated). Only create these for
+domains that have real depth — not for simple integrations that fit
+in a few lines of architecture.md.
+
+After populating context/ files, update ROUTER.md:
+- Fill in the Current Project State section based on what you found
+- Add rows to the routing table for any domain-specific context files you created
+
+Update AGENTS.md:
+- Fill in the project name, one-line description, non-negotiables, and commands
+
+PASS 2 — Generate starter patterns:
+
+Read patterns/README.md for the format and categories.
+
+Generate 3-5 starter patterns for the most common and most dangerous task
+types in this project. Focus on:
+- The 1-2 tasks a developer does most often (e.g., add endpoint, add component)
+- The 1-2 integrations with the most non-obvious gotchas
+- 1 debug pattern for the most common failure boundary
+
+Each pattern should be specific to this project — real file paths, real gotchas,
+real verify steps derived from the code you read in Pass 1.
+Use the format in patterns/README.md. Name descriptively (e.g., add-endpoint.md).
+
+Do NOT try to generate a pattern for every possible task type. The scaffold
+grows incrementally — the behavioural contract (step 5: GROW) will create
+new patterns from real work as the project evolves. Setup just seeds the most
+critical ones.
+
+After generating patterns, update patterns/INDEX.md with a row for each
+pattern file you created. For multi-section patterns, add one row per task
+section using anchor links (see INDEX.md annotation for format).
+
+PASS 3 — Wire the web:
+
+Re-read every file you just wrote (context/ files, pattern files, ROUTER.md).
+For each file, add or update the `edges` array in the YAML frontmatter.
+Each edge should point to another scaffold file that is meaningfully related,
+with a `condition` explaining when an agent should follow that edge.
+
+Rules for edges:
+- Every context/ file should have at least 2 edges
+- Every pattern file should have at least 1 edge (usually to the relevant context file)
+- Edges should be bidirectional where it makes sense (if A links to B, consider B linking to A)
+- Use relative paths (e.g., context/stack.md, patterns/add-endpoint.md)
+- Pattern files can edge to other patterns (e.g., debug pattern → related task pattern)
+
+Important: only write content derived from the codebase.
+Do not include system-injected text (dates, reminders, etc.)
+in any scaffold file.
+
+When done, confirm which files were populated and flag any slots
+you could not fill with confidence.
+```
+
+---
+
+## Option B — Fresh Project
+
+Paste the following prompt into your agent:
+
+---
+
+**SETUP PROMPT — copy everything between the lines:**
+
+```
+You are going to populate an AI context scaffold for a project that
+is just starting. Nothing is built yet.
+
+Read the following files in order before doing anything else:
+1. ROUTER.md — understand the scaffold structure
+2. All files in context/ — read the annotation comments in each
+
+Then ask me the following questions one section at a time.
+Wait for my answer before moving to the next section:
+
+1. What does this project do? (one sentence)
+2. What are the hard rules — things that must never happen in this codebase?
+3. What is the tech stack? (language, framework, database, key libraries)
+4. Why did you choose this stack over alternatives?
+5. How will the major pieces connect? Describe the flow of a typical request/action.
+6. What patterns do you want to enforce from day one?
+7. What are you deliberately NOT building or using?
+
+After I answer, populate the context/ files based on my answers.
+For any slot you cannot fill yet, write "[TO BE DETERMINED]" and note
+what needs to be decided before it can be filled.
+
+Then assess: based on my answers, does this project have domains complex
+enough that cramming them into architecture.md would make it too long
+or too shallow? If yes, create additional domain-specific context files
+in context/. Examples: a project with a complex auth system gets
+context/auth.md. A data pipeline gets context/ingestion.md. A project
+with Stripe gets context/payments.md. Use the same YAML frontmatter
+format (name, description, triggers, edges, last_updated). Only create
+these for domains that have real depth — not for simple integrations
+that fit in a few lines of architecture.md. For fresh projects, mark
+domain-specific unknowns with "[TO BE DETERMINED — populate after first
+implementation]".
+
+Update ROUTER.md current state to reflect that this is a new project.
+Add rows to the routing table for any domain-specific context files you created.
+Update AGENTS.md with the project name, description, non-negotiables, and commands.
+
+Read patterns/README.md for the format and categories.
+
+Generate 2-3 starter patterns for the most obvious task types you can
+anticipate for this stack. Focus on the tasks a developer will do first.
+Mark unknowns with "[VERIFY AFTER FIRST IMPLEMENTATION]".
+
+Do NOT try to anticipate every possible pattern. The scaffold grows
+incrementally — the behavioural contract (step 5: GROW) will create
+new patterns from real work as the project evolves. Setup just seeds
+the most critical ones.
+
+After generating patterns, update patterns/INDEX.md with a row for each
+pattern file you created.
+
+PASS 3 — Wire the web:
+
+Re-read every file you just wrote (context/ files, pattern files, ROUTER.md).
+For each file, add or update the `edges` array in the YAML frontmatter.
+Each edge should point to another scaffold file that is meaningfully related,
+with a `condition` explaining when an agent should follow that edge.
+
+Rules for edges:
+- Every context/ file should have at least 2 edges
+- Every pattern file should have at least 1 edge
+- Edges should be bidirectional where it makes sense
+- Use relative paths (e.g., context/stack.md, patterns/add-endpoint.md)
+
+Important: only write content derived from your answers.
+Do not include system-injected text (dates, reminders, etc.)
+in any scaffold file.
+```
+
+---
+
+## After Setup
+
+**Verify** by starting a fresh session and asking your agent:
+"Read `.mex/ROUTER.md` and tell me what you now know about this project."
+
+A well-populated scaffold should give the agent enough to:
+- Describe the architecture without looking at code
+- Name the non-negotiable conventions
+- Know which files to load for any given task type
+- Know which patterns exist for common task types
+
+## Keeping It Fresh
+
+Once the scaffold is populated, use these to keep it aligned with your codebase:
+
+- **`mex check`** — detect drift (zero tokens, zero AI)
+- **`.mex/sync.sh`** — interactive drift check + targeted or full resync
+- **`mex watch`** — auto drift score after every commit

--- a/.mex/SYNC.md
+++ b/.mex/SYNC.md
@@ -1,0 +1,62 @@
+# Sync — Realign This Scaffold
+
+## Recommended: Use sync.sh
+
+```bash
+.mex/sync.sh
+```
+
+The script runs drift detection first, shows you exactly what's wrong, then offers:
+1. **Targeted sync** — AI fixes only the flagged files (fastest, cheapest)
+2. **Full resync** — AI re-reads everything and updates all scaffold files
+3. **Prompt export** — shows the prompts for manual paste
+4. **Exit** — fix it yourself
+
+## Quick Check
+
+```bash
+mex check              # full drift report
+mex check --quiet      # one-liner: "drift score 85/100 (1 error)"
+mex sync --dry-run     # preview targeted fix prompts
+```
+
+## Manual Resync
+
+If you prefer to paste a prompt manually, or don't have the CLI built:
+
+---
+
+**SYNC PROMPT — copy everything between the lines:**
+
+```
+You are going to resync the AI context scaffold for this project.
+The scaffold may be out of date — the codebase has changed since it was last populated.
+
+First, read all files in context/ to understand the current scaffold state.
+Then explore what has changed in the codebase since the scaffold was last updated.
+Check the last_updated dates in the YAML frontmatter of each file.
+
+For each context/ file:
+1. Compare the current scaffold content to the actual codebase
+2. Identify what has changed, been added, or been removed
+3. Update the file to reflect the current state
+
+Critical rules for updating:
+- Use surgical, targeted edits — NOT full file rewrites. Read the existing content,
+  identify what changed, and update only those sections.
+- PRESERVE YAML frontmatter structure. Never delete or rewrite the entire frontmatter block.
+  Edit individual fields only. The edges, triggers, name, and description fields must
+  survive every sync. If you need to update edges, add or remove individual entries —
+  do not replace the entire array.
+- In context/decisions.md: NEVER delete existing decisions.
+  If a decision has changed, mark the old entry as "Superseded by [new decision title]"
+  and add the new decision above it with today's date.
+- In all other files: update content to reflect current reality
+- Update last_updated in the YAML frontmatter of every file you change
+- After updating each file, update ROUTER.md Current Project State
+
+When done, report:
+- Which files were updated and what changed
+- Any decisions that were superseded
+- Any slots that could not be filled with confidence
+```

--- a/.mex/config.json
+++ b/.mex/config.json
@@ -1,0 +1,10 @@
+{
+  "scaffold_id": "f2195320-dcf1-4f65-992f-452811f820cf",
+  "scaffold_name": "plio-backend",
+  "origin": null,
+  "upstream": null,
+  "aiTools": [
+    "claude",
+    "codex"
+  ]
+}

--- a/.mex/context/architecture.md
+++ b/.mex/context/architecture.md
@@ -1,0 +1,53 @@
+---
+name: architecture
+description: How the major pieces of this project connect and flow. Load when working on system design, integrations, or understanding how components interact.
+triggers:
+  - "architecture"
+  - "system design"
+  - "how does X connect to Y"
+  - "integration"
+  - "flow"
+edges:
+  - target: context/stack.md
+    condition: when specific technology details are needed
+  - target: context/decisions.md
+    condition: when understanding why the architecture is structured this way
+last_updated: 2026-07-11
+---
+
+# Architecture
+
+## System Overview
+
+Request arrives → tenant middleware (`organizations/middleware.py`, OrganizationTenantMiddleware)
+reads the `Organization` header (falling back to DEFAULT_TENANT_SHORTCODE) and switches the
+Postgres connection to that workspace's schema → OAuth2 authentication resolves the Bearer
+token → DRF ViewSet + serializer handle the resource → frequently-read entities
+(plio/video/item/question/image/user) are served from Redis when cached, with tenant-scoped
+keys from `plio/cache.py` → response serialized back. Heavier reads (plio metrics, report
+downloads) run raw SQL from `plio/queries.py` against the current schema, post-processed with
+pandas. Separately, Django Channels keeps a WebSocket per user (`users/consumers.py`) and
+pushes the serialized user object on updates via Redis channel layers.
+
+## Key Components
+
+- **plio** (project package AND core app) — settings/urls/asgi live in `plio/settings.py`, `plio/urls.py`; the app also owns Video, Plio, Item, Question, Image models, their viewsets, `plio/cache.py` (Redis key map + invalidation helpers), and `plio/queries.py` (raw SQL for metrics/reports)
+- **entries** — runtime learner data: Session, SessionAnswer, Event; high write volume during playback
+- **users** — custom User model (email/mobile based, optional unique_id + auth_org), roles, org membership, OTP flow, external-auth token endpoint, WebSocket consumer
+- **organizations** — Organization (tenant: shortcode, schema_name, api_key) + Domain models and the tenant middleware
+- **experiments / tags / etl** — A/B experiment scaffolding, polymorphic tagging, BigQuery sync job registry (guarded by ETLPermissions)
+
+## External Dependencies
+
+- **PostgreSQL** (postgres:11 in docker) — one schema per workspace via django-tenants; public schema holds shared apps
+- **Redis** (redis:5 in docker) — entity cache (django-redis) and channel layer for WebSockets (channels_redis)
+- **AWS S3** — question image storage via django-storages/boto3 (`AWS_STORAGE_BUCKET_NAME`)
+- **AWS SNS** — outbound OTP SMS when `SMS_DRIVER=sns`
+- **Google OAuth2** — social login exchanged for internal OAuth tokens at `/auth/convert-token/`
+- **Sentry** — error monitoring (staging/production); **BigQuery** — analytics sync via the etl app
+
+## What Does NOT Exist Here
+
+- No frontend rendering — the Vue SPA (plio-frontend repo) is the only consumer besides embeds; this service is API + Django admin only
+- No background job queue (no celery) — ETL sync is driven through the bigquery-jobs registry, everything else is request-cycle
+- No hard deletes — django-safedelete intercepts deletion across models

--- a/.mex/context/conventions.md
+++ b/.mex/context/conventions.md
@@ -1,0 +1,69 @@
+---
+name: conventions
+description: How code is written in this project — naming, structure, patterns, and style. Load when writing new code or reviewing existing code.
+triggers:
+  - "convention"
+  - "pattern"
+  - "naming"
+  - "style"
+  - "how should I"
+  - "what's the right way"
+edges:
+  - target: context/architecture.md
+    condition: when a convention depends on understanding the system structure
+last_updated: 2026-07-11
+---
+
+# Conventions
+
+## Naming
+
+- Django apps are plural lowercase (`users`, `organizations`, `entries`, `experiments`, `tags`) except the core `plio` app; each app follows the standard models/serializers/views/urls layout
+- Models: PascalCase singular (Plio, SessionAnswer, OrganizationUser); tables/columns snake_case via Django defaults
+- API routes: kebab/plural resource roots under `/api/v1/` (`/plios/`, `/session-answers/`, `/organization-users/`)
+- Cache keys: `<entity>_<schema>_<id>` for tenant-scoped entities, `<entity>_<id>` for global ones — built only in `plio/cache.py`
+- Code style enforced by black + flake8 through pre-commit (`.pre-commit-config.yaml`)
+
+## Structure
+
+- Every resource is a DRF ViewSet registered on the router in `plio/urls.py` — no function-based API views
+- Business logic lives on viewsets/serializers/model methods within the owning app; cross-app imports flow toward `plio` (core), not away from it
+- Raw SQL is confined to `plio/queries.py` and always executes against the current tenant schema
+- Settings are environment-driven via `.env` (see `docs/ENV.md`); no per-developer settings files
+- Tests live in each app (`test_views.py` etc.) and use DRF's `APITestCase` hitting real endpoints
+
+## Patterns
+
+Tenant-aware queries — the schema is set by middleware from the `Organization` header; to touch
+another workspace explicitly, switch schema deliberately (as `PlioViewSet.copy` does) and switch
+back; never hardcode schema names.
+
+Soft delete — models use django-safedelete, so:
+
+```python
+# Correct — respects soft delete
+Plio.objects.filter(uuid=uuid).first()  # excludes soft-deleted by default
+
+# Wrong — resurrects or double-counts soft-deleted rows
+Plio.objects.all_with_deleted()  # only for explicit undelete/audit flows
+```
+
+Cache invalidation — after mutating a cached entity:
+
+```python
+from plio.cache import invalidate_cache_for_instance
+invalidate_cache_for_instance(instance)  # tenant-scoped key handled for you
+```
+
+Serializer expansion cost — UserSerializer expands organizations/roles per user; for lookups use
+query params (`/users/?email=<email>` or `?ids=`) instead of listing and filtering in Python.
+
+## Verify Checklist
+
+Before presenting any code:
+- [ ] `pre-commit run --all-files` passes (black + flake8)
+- [ ] Tests pass: `docker-compose exec web python manage.py test` (or `coverage run manage.py test`)
+- [ ] New/changed models: migration generated, placed in the right SHARED_APPS/TENANT_APPS bucket, and no unexpected migrations for other apps
+- [ ] Mutations to cached entities invalidate via `plio/cache.py` helpers
+- [ ] Endpoint works with an `Organization` header set AND absent (falls back to default tenant)
+- [ ] No hard deletes and no raw cache key strings introduced

--- a/.mex/context/decisions.md
+++ b/.mex/context/decisions.md
@@ -1,0 +1,45 @@
+---
+name: decisions
+description: Key architectural and technical decisions with reasoning. Load when making design choices or understanding why something is built a certain way.
+triggers:
+  - "why do we"
+  - "why is it"
+  - "decision"
+  - "alternative"
+  - "we chose"
+last_updated: 2026-07-11
+---
+
+# Decisions
+
+## Decision Log
+
+### Schema-per-workspace multi-tenancy with django-tenants
+**Date:** 2021 (original architecture, verified 2026-07-11)
+**Status:** Active
+**Decision:** Each organization/workspace gets its own Postgres schema; the `Organization` request header (org shortcode) selects the schema via middleware; shared models (users, organizations) live in the public schema.
+**Reasoning:** Hard isolation of workspace data (learner sessions, plios) with one database to operate; a header-based switch keeps the API surface identical for all tenants.
+**Alternatives considered:** Row-level tenancy with a foreign key (rejected — weaker isolation, every query must remember the filter).
+**Consequences:** Every request without the header lands on the default tenant; cross-workspace features (plio copy) must switch schemas explicitly; cache keys must embed the schema name.
+
+### Soft delete everywhere via django-safedelete
+**Date:** 2021 (original architecture, verified 2026-07-11)
+**Status:** Active
+**Decision:** Models use safedelete policies instead of hard deletion.
+**Reasoning:** Learner data and creator content are analytically valuable and deletion is often accidental; recovery beats backups.
+**Consequences:** Unique constraints and counts must account for soft-deleted rows; default managers exclude them, which surprises raw SQL (queries in `plio/queries.py` must filter deleted rows themselves).
+
+### Issue internal OAuth2 tokens for every auth flow
+**Date:** 2021 (original architecture, verified 2026-07-11)
+**Status:** Active
+**Decision:** Google login, OTP, and third-party SSO all converge on the same internal OAuth2 provider — external identity is exchanged for a Plio access/refresh token pair.
+**Reasoning:** One authorization model downstream: DRF permissions only ever see internal Bearer tokens regardless of how the user logged in.
+**Consequences:** Third parties integrate by exchanging their org `api_key` + user `unique_id` at `/auth/generate-external-auth-access-token/`; token lifetime/refresh policy is controlled centrally.
+
+### Upgrade Django via a chained, reviewable PR sequence
+**Date:** 2026-05-06
+**Status:** Active (chain unmerged as of 2026-07-11)
+**Decision:** Move master from Django 3.1.1 to 5.2.14 LTS through stepwise PRs (#354–#360), one Django version hop each (3.2 → 4.0 → 4.1 → 4.2 → 5.0 → 5.1 → 5.2), each validated by the full test suite plus added smoke tests.
+**Reasoning:** A single mega-upgrade of a 4-major-version gap across tenants, soft delete, channels, and OAuth is unreviewable and undebuggable; per-version PRs isolate breakage.
+**Alternatives considered:** Direct 3.1 → 5.2 jump (rejected — too many interacting breaking changes).
+**Consequences:** PRs must merge in order, oldest first; master stays on old pins until then; sentry-sdk/daphne upgrades and the django-request-logging replacement are deliberately deferred to separate follow-up PRs.

--- a/.mex/context/setup.md
+++ b/.mex/context/setup.md
@@ -1,0 +1,63 @@
+---
+name: setup
+description: Dev environment setup and commands. Load when setting up the project for the first time or when environment issues arise.
+triggers:
+  - "setup"
+  - "install"
+  - "environment"
+  - "getting started"
+  - "how do I run"
+  - "local development"
+edges:
+  - target: context/stack.md
+    condition: when specific technology versions or library details are needed
+  - target: context/architecture.md
+    condition: when understanding how components connect during setup
+last_updated: 2026-07-11
+---
+
+# Setup
+
+## Prerequisites
+
+- Docker Desktop (the supported dev flow — Postgres, Redis, and the app all run in compose)
+- pre-commit (`pip install pre-commit` or `brew install pre-commit`) for the git hooks
+- Python 3.8 if running outside docker (CI uses 3.8)
+
+## First-time Setup
+
+1. `cp .env.example .env` and fill values (full reference: `docs/ENV.md`)
+2. `docker-compose up -d --build` — brings up db (postgres:11), redis (redis:5), and web
+3. `pre-commit install` (dev only)
+4. Configure a login method: OTP (`docs/ONE-TIME-PIN.md`) or Google sign-in (docs/oauth/ guide)
+5. API at http://0.0.0.0:8001/api/v1 — docs at /api/v1/docs/ — Django admin at http://0.0.0.0:8001/admin
+6. Full walkthrough: `docs/INSTALLATION.md`
+
+## Environment Variables
+
+- `SECRET_KEY`, `DEBUG`, `APP_ENV`, `ALLOWED_HOSTS`, `APP_PORT` (required) — core Django/runtime
+- `DB_ENGINE`, `DB_HOST`, `DB_NAME`, `DB_PORT`, `DB_USER`, `DB_PASSWORD` (required) — Postgres; in docker, `DB_HOST=db`
+- `REDIS_HOSTNAME`, `REDIS_PORT` (required) — cache + channels
+- `DEFAULT_TENANT_NAME`, `DEFAULT_TENANT_SHORTCODE`, `DEFAULT_TENANT_DOMAIN` (required) — the fallback public tenant
+- `SUPERUSER_EMAIL`, `SUPERUSER_PASSWORD` (required) — bootstrap admin
+- `DEFAULT_OAUTH2_CLIENT_SETUP`, `DEFAULT_OAUTH2_CLIENT_ID`, `DEFAULT_OAUTH2_CLIENT_SECRET` (required) — internal OAuth app (also via `python manage.py createoauth2application`)
+- `GOOGLE_OAUTH2_CLIENT_ID`, `GOOGLE_OAUTH2_CLIENT_SECRET` (required for Google login)
+- `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION` (required for S3 images / SNS OTP), `AWS_STORAGE_BUCKET_NAME` (S3), `SMS_DRIVER` (`sns` to send real SMS)
+- `SENTRY_DSN` (optional) — error monitoring
+
+## Common Commands
+
+- `docker-compose up -d --build` — build and start the full stack
+- `docker-compose exec web python manage.py test` — run the test suite in the container
+- `coverage run manage.py test` — how CI runs tests (then uploads to Codecov)
+- `docker-compose exec web python manage.py makemigrations` / `migrate` — schema changes
+- `docker-compose exec web python manage.py shell` — Django shell (tenant-aware helpers in `docs/MULTITENANCY.md`)
+- `pre-commit run --all-files` — black + flake8 + hygiene hooks
+- `docker-compose logs -f web` — tail app logs
+
+## Common Issues
+
+**DB connection refused from the app:** `DB_HOST` must be `db` (the compose service name) inside docker — `localhost` only works from the host machine.
+**401s on every endpoint after fresh setup:** no OAuth2 application exists yet — set the `DEFAULT_OAUTH2_CLIENT_*` vars or run `python manage.py createoauth2application`, and make sure the frontend uses the same client id/secret.
+**Wrong or empty data for a workspace:** the request's `Organization` header doesn't match an existing tenant shortcode, so it fell back to the default tenant.
+**Migrations touching apps you didn't change:** check the SHARED_APPS/TENANT_APPS split in `plio/settings.py` before applying — a model in the wrong bucket migrates into every schema.

--- a/.mex/context/stack.md
+++ b/.mex/context/stack.md
@@ -1,0 +1,51 @@
+---
+name: stack
+description: Technology stack, library choices, and the reasoning behind them. Load when working with specific technologies or making decisions about libraries and tools.
+triggers:
+  - "library"
+  - "package"
+  - "dependency"
+  - "which tool"
+  - "technology"
+edges:
+  - target: context/decisions.md
+    condition: when the reasoning behind a tech choice is needed
+  - target: context/conventions.md
+    condition: when understanding how to use a technology in this codebase
+last_updated: 2026-07-11
+---
+
+# Stack
+
+## Core Technologies
+
+- **Python 3.8** (CI target) with **Django 3.1.1** on master — a migration chain to Django 5.2.14 LTS exists as unmerged PRs #354–#360; don't use newer Django APIs on master
+- **Django REST Framework 3.12.2** — every endpoint is a DRF ViewSet routed under `/api/v1/`
+- **PostgreSQL 11** — schema-per-tenant via django-tenants
+- **Redis 5** — cache backend and channels layer
+- **Docker Compose** — the supported dev environment (services: db, web, redis)
+
+## Key Libraries
+
+- **django-tenants 3.2.1** — multi-tenancy backbone; SHARED_APPS vs TENANT_APPS split in `plio/settings.py`
+- **django-safedelete 1.0.0** — soft delete on models; deleted rows stay in the table
+- **django-rest-framework-social-oauth2 1.1.0** — Google login token conversion; internal OAuth2 provider issues access/refresh tokens
+- **channels 3.0.3** + **channels_redis** — WebSocket support (ASGI)
+- **django-redis 5.0.0** — cache; always use the helpers in `plio/cache.py`, not raw cache calls, so keys stay tenant-scoped
+- **pandas** + **pyarrow** — metrics/report post-processing over raw SQL from `plio/queries.py`
+- **boto3 / django-storages** — S3 image storage and SNS SMS
+- **drf-yasg 1.20.0** — API docs at `/api/v1/docs/`
+- **django-silk** — profiling in local/staging; **sentry-sdk** — error monitoring
+- **coverage 5.5** — test coverage (CI uploads to Codecov)
+
+## What We Deliberately Do NOT Use
+
+- No celery/task queue — nothing here should assume async background workers exist
+- No pytest — tests are Django `TestCase`/DRF `APITestCase` style, run with `manage.py test`
+- No raw `cache.set/get` with hand-built keys — tenant-scoped key builders in `plio/cache.py` only
+- No ORM `.delete()` semantics assumptions — safedelete changes behaviour; see the soft-delete pattern
+
+## Version Constraints
+
+- Master is intentionally frozen on old pins (Django 3.1.1, DRF 3.12.2) until the migration PR chain (#354–#360) merges — the chain must merge in order, oldest first
+- django-request-logging 0.7.2 is abandoned upstream; keep it until its replacement PR (deferred, post-migration)

--- a/.mex/events/decisions.jsonl
+++ b/.mex/events/decisions.jsonl
@@ -1,0 +1,1 @@
+{"timestamp":"2026-07-11T17:00:51.094Z","kind":"decision","message":"mex scaffold created and populated (Claude + Codex configs; CLAUDE.md symlinks to AGENTS.md). Master is on Django 3.1.1 — migration chain PRs #354-#360 pending.","files":[],"cwd":"."}

--- a/.mex/patterns/INDEX.md
+++ b/.mex/patterns/INDEX.md
@@ -1,0 +1,9 @@
+# Pattern Index
+
+Lookup table for all pattern files in this directory. Check here before starting any task — if a pattern exists, follow it.
+
+| Pattern | Use when |
+|---------|----------|
+| [add-api-endpoint.md](add-api-endpoint.md) | Adding a new DRF resource, model, or custom viewset action |
+| [run-tests-and-migrations.md](run-tests-and-migrations.md) | Running the test suite or creating/applying migrations |
+| [tenancy-and-caching.md](tenancy-and-caching.md) | Any work touching tenant schemas, the Organization header, or the Redis cache |

--- a/.mex/patterns/README.md
+++ b/.mex/patterns/README.md
@@ -1,0 +1,170 @@
+# Patterns
+
+This folder contains task-specific guidance — the things you would tell your agent if you were sitting next to it. Not generic instructions. Project-specific accumulated wisdom.
+
+## How patterns get created
+
+**During setup:** After the context/ files are populated, the agent generates starter patterns based on the project's actual stack, architecture, and conventions. These are stack-specific — a Flask API project gets different patterns than a React SPA or a CLI tool.
+
+**Over time:** You or your agent add patterns as they emerge from real work — when something breaks, when a task has a non-obvious gotcha, when you've explained the same thing twice.
+
+## What belongs here
+
+A pattern file is worth creating when:
+- A task type is common in this project and has a repeatable workflow
+- There are integration gotchas between components that aren't obvious from code
+- Something broke and you want to prevent it from breaking the same way again
+- A verify checklist specific to one type of task would catch mistakes early
+
+## When to skip a pattern
+
+Default to generating a pattern. Only skip if:
+- The exact same guidance is already in `context/conventions.md` with concrete examples
+- The task truly has no project-specific gotchas (e.g. "how to write a for loop")
+
+If in doubt, generate the pattern. A pattern that turns out to be obvious costs nothing. A missing pattern costs a broken codebase.
+
+## Format
+
+### Single-task pattern (one file = one task)
+
+```markdown
+---
+name: [pattern-name]
+description: [one line — what this pattern covers and when to use it]
+triggers:
+  - "[keyword that should trigger loading this file]"
+edges:
+  - target: "[related file path, e.g. context/conventions.md]"
+    condition: "[when to follow this edge]"
+last_updated: [YYYY-MM-DD]
+---
+
+# [Pattern Name]
+
+## Context
+[What to load or know before starting this task type]
+
+## Steps
+[The workflow — what to do, in what order]
+
+## Gotchas
+[The things that go wrong. What to watch out for.]
+
+## Verify
+[Checklist to run after completing this task type]
+
+## Debug
+[What to check when this task type breaks]
+
+## Update Scaffold
+- [ ] Update `.mex/ROUTER.md` "Current Project State" if what's working/not built has changed
+- [ ] Update any `.mex/context/` files that are now out of date
+- [ ] If this is a new task type without a pattern, create one in `.mex/patterns/` and add to `INDEX.md`
+```
+
+### Multi-section pattern (one file = multiple related tasks)
+
+Use this when tasks share context but differ in steps. Each task gets its own
+`## Task: ...` heading with sub-sections. The Context section is shared at the top.
+
+```markdown
+---
+name: [pattern-name]
+description: [one line — what this pattern file covers]
+triggers:
+  - "[keyword]"
+edges:
+  - target: "[related file path]"
+    condition: "[when to follow this edge]"
+last_updated: [YYYY-MM-DD]
+---
+
+# [Pattern Name]
+
+## Context
+[Shared context for all tasks in this file]
+
+## Task: [First Task Name]
+
+### Steps
+[...]
+
+### Gotchas
+[...]
+
+### Verify
+[...]
+
+## Task: [Second Task Name]
+
+### Steps
+[...]
+
+## Update Scaffold
+- [ ] Update `.mex/ROUTER.md` "Current Project State" if what's working/not built has changed
+- [ ] Update any `.mex/context/` files that are now out of date
+- [ ] If this is a new task type without a pattern, create one in `.mex/patterns/` and add to `INDEX.md`
+```
+
+Do NOT combine unrelated tasks into one file just to reduce file count.
+Only group tasks that genuinely share context.
+
+## How many patterns to generate
+
+Do not use a fixed number. Generate one pattern per:
+- Each major task type a developer does repeatedly in this project
+- Each external dependency with non-obvious integration gotchas
+- Each major failure boundary in the architecture flow
+
+For a simple project this may be 3-4 files. For a complex project this may be 10-15.
+Do not cap based on a number — cap based on whether the pattern adds real value.
+
+## Pattern categories
+
+Walk through each category below. For each one, check the relevant context files
+and generate patterns for everything that applies to this project.
+
+### Category 1 — Common task patterns
+
+The repeatable tasks in this project. What does a developer do most often?
+
+Derive from: `context/architecture.md` (what are the major components?) and
+`context/conventions.md` (what patterns exist for extending them?)
+
+Examples by project type:
+- API: "add new endpoint", "add new model/entity", "add auth to a route"
+- Frontend: "add new page/route", "add new component", "add form with validation"
+- CLI: "add new command", "add new flag/option"
+- Pipeline: "add new pipeline stage", "add new data source"
+- SaaS: "add payment flow", "add user-facing feature", "add admin operation"
+
+### Category 2 — Integration patterns
+
+How to work with the external dependencies in this project.
+
+Every entry in `context/stack.md` "Key Libraries" or `context/architecture.md`
+"External Dependencies" that has non-obvious setup, gotchas, or failure modes
+deserves a pattern. These are the most dangerous areas — the agent will
+confidently write integration code that looks right but misses project-specific
+configuration, error handling, or rate limiting.
+
+Examples: "calling the payments API", "running database migrations",
+"adding a new third-party service client", "configuring auth provider"
+
+### Category 3 — Debug/diagnosis patterns
+
+When something breaks, where do you look?
+
+Derive from the architecture flow — each boundary between components is a
+potential failure point. One debug pattern per major boundary.
+
+Examples: "debug webhook failures", "debug pipeline stage failures",
+"diagnose auth/permission issues", "debug background job failures"
+
+### Category 4 — Deploy/release patterns
+
+Only generate if `context/setup.md` reveals non-trivial deployment.
+
+Examples: "deploy to staging", "rollback a release", "update environment config",
+"run database migration in production"

--- a/.mex/patterns/add-api-endpoint.md
+++ b/.mex/patterns/add-api-endpoint.md
@@ -1,0 +1,51 @@
+---
+name: add-api-endpoint
+description: Adding a new DRF resource (model + serializer + viewset + route) or a custom action on an existing viewset.
+triggers:
+  - "new endpoint"
+  - "new model"
+  - "new viewset"
+  - "add action"
+edges:
+  - target: "context/conventions.md"
+    condition: "for structure and naming rules before writing code"
+last_updated: 2026-07-11
+---
+
+# Add an API Endpoint / Resource
+
+## Context
+Every resource is a DRF ViewSet registered on the router in `plio/urls.py` under `/api/v1/`.
+Models are soft-deleted (django-safedelete) and may be tenant-scoped (live in a TENANT_APPS app)
+or shared (SHARED_APPS). Default permission is IsAuthenticated with OAuth2.
+
+## Steps
+1. Decide tenancy first: does this data belong to a workspace (tenant schema) or to everyone (public schema)? That decides which app it lives in and how it migrates.
+2. Add the model with the appropriate safedelete policy; generate the migration and inspect it before applying.
+3. Add a serializer; keep expansion of related objects deliberate — expensive expansions (like UserSerializer) need filtered list endpoints, not full lists.
+4. Add the ViewSet; custom behaviours go in actions (like PlioViewSet's play/duplicate/copy/metrics) rather than new ad-hoc views.
+5. Register on the router in `plio/urls.py`.
+6. If reads are hot, wire caching through `plio/cache.py` — add the key builder there and invalidate on mutation.
+7. Add `APITestCase` tests in the owning app hitting the real endpoint, including one request with an `Organization` header and one without.
+
+## Gotchas
+- A model in the wrong SHARED_APPS/TENANT_APPS bucket migrates into every schema (or none) — this is the most expensive mistake in this codebase
+- Soft delete + unique constraints interact: a "deleted" row still occupies unique values unless the constraint accounts for it
+- Custom permissions: resource-level rules follow the PlioPermission example, driven by org membership (OrganizationUser) and the header workspace
+
+## Verify
+- [ ] Migration reviewed: right app bucket, no surprise changes to other apps
+- [ ] Endpoint behaves correctly with and without an `Organization` header
+- [ ] Cache invalidation covered if the entity is cached
+- [ ] Tests added and `docker-compose exec web python manage.py test` passes
+- [ ] `pre-commit run --all-files` clean
+
+## Debug
+- 404 on a route you just added → router registration in `plio/urls.py` (check the basename)
+- Data appearing in the wrong workspace → the model's app is in the wrong tenancy bucket
+- Stale reads after writes → missing invalidation call in the mutation path
+
+## Update Scaffold
+- [ ] Update `.mex/ROUTER.md` "Current Project State" if what's working/not built has changed
+- [ ] Update any `.mex/context/` files that are now out of date
+- [ ] If this is a new task type without a pattern, create one in `.mex/patterns/` and add to `INDEX.md`

--- a/.mex/patterns/run-tests-and-migrations.md
+++ b/.mex/patterns/run-tests-and-migrations.md
@@ -1,0 +1,49 @@
+---
+name: run-tests-and-migrations
+description: Running the test suite and handling migrations in the dockerized dev environment, including soft-delete and tenancy wrinkles.
+triggers:
+  - "run tests"
+  - "test suite"
+  - "migration"
+  - "makemigrations"
+  - "migrate"
+edges:
+  - target: "context/setup.md"
+    condition: "if the docker environment isn't up yet"
+last_updated: 2026-07-11
+---
+
+# Run Tests & Migrations
+
+## Context
+The supported environment is docker compose (services: db, web, redis). Tests are Django/DRF
+style (`APITestCase`), run through `manage.py test` — there is no pytest. CI (GitHub Actions)
+runs `coverage run manage.py test` on Python 3.8 and uploads to Codecov.
+
+## Steps
+1. Ensure the stack is up: `docker-compose up -d --build`
+2. Full suite: `docker-compose exec web python manage.py test`
+3. One app or case: `docker-compose exec web python manage.py test users` (or a dotted path to a test class/method)
+4. Migrations: `docker-compose exec web python manage.py makemigrations` → inspect the generated files → `docker-compose exec web python manage.py migrate`
+5. Before committing: `pre-commit run --all-files`
+
+## Gotchas
+- makemigrations with no model changes can still emit migrations if a third-party package (notably django-safedelete) changes model state between versions — treat unexpected migrations as a red flag, not noise
+- Tenant apps migrate per schema — a migration that's instant on the public schema multiplies across every workspace schema in production
+- Image-related tests use a local-storage mixin so S3 isn't hit — don't add tests that require real AWS credentials
+- Silk profiling middleware is active in local settings; it can distort timing-sensitive assertions
+
+## Verify
+- [ ] Full suite green locally before pushing (CI mirrors it with coverage)
+- [ ] `makemigrations` after your change emits nothing unexpected (run it once more to confirm a clean state)
+- [ ] pre-commit hooks pass
+
+## Debug
+- Tests can't connect to db/redis → containers not up, or env points at localhost instead of the compose service names (`db`, `redis`)
+- A "random" migration appears for an app you didn't touch → diff the package versions first (safedelete is the usual suspect)
+- Auth-dependent tests failing en masse → the test OAuth application setup didn't run; check `DEFAULT_OAUTH2_CLIENT_SETUP` handling in test settings
+
+## Update Scaffold
+- [ ] Update `.mex/ROUTER.md` "Current Project State" if what's working/not built has changed
+- [ ] Update any `.mex/context/` files that are now out of date
+- [ ] If this is a new task type without a pattern, create one in `.mex/patterns/` and add to `INDEX.md`

--- a/.mex/patterns/tenancy-and-caching.md
+++ b/.mex/patterns/tenancy-and-caching.md
@@ -1,0 +1,52 @@
+---
+name: tenancy-and-caching
+description: Working safely with tenant schemas and the tenant-scoped Redis cache — the two cross-cutting systems everything else sits on.
+triggers:
+  - "tenant"
+  - "workspace"
+  - "organization header"
+  - "cache"
+  - "redis"
+  - "schema"
+edges:
+  - target: "context/architecture.md"
+    condition: "for the request flow through middleware before changing tenancy behaviour"
+last_updated: 2026-07-11
+---
+
+# Tenancy & Caching
+
+## Context
+The `Organization` header picks the Postgres schema per request (middleware in
+`organizations/middleware.py`); no header means the default tenant. The Redis cache embeds the
+schema in keys for tenant entities (`plio_<schema>_<id>`) and not for global ones (`user_<id>`)
+— all key building and invalidation lives in `plio/cache.py`.
+
+## Steps
+1. Read `docs/MULTITENANCY.md` and `docs/CACHING.md` for the canonical shell recipes before touching either system.
+2. For any query, know which schema you're on — inside a request it's set by the header; in shell/scripts you must set it explicitly before querying tenant models.
+3. To operate on another workspace mid-request (cross-tenant features), follow `PlioViewSet.copy`: switch the connection schema deliberately, do the work, and invalidate the destination's cache keys.
+4. When adding cached reads: add the key builder to `plio/cache.py`, and hook invalidation into every mutation path (including bulk operations and cross-tenant copies).
+5. Raw SQL (in `plio/queries.py`) executes against the current connection schema — verify the schema before running, and filter soft-deleted rows explicitly.
+
+## Gotchas
+- The header value is an org shortcode, not an id or schema name — an unknown shortcode silently falls back to the default tenant instead of erroring
+- Users/organizations are shared (public schema); sessions/plios/items are tenant data — a join across that boundary needs care
+- Cache keys built anywhere except `plio/cache.py` will eventually diverge from the invalidation logic — that's the whole reason the helpers exist
+- After a cross-tenant write, invalidating the *source* tenant's keys does nothing — invalidate in the *destination* schema context
+
+## Verify
+- [ ] Behaviour correct for: valid header, missing header (default tenant), unknown shortcode
+- [ ] Tenant isolation: data written in workspace A is not readable from workspace B
+- [ ] Every mutation of a cached entity invalidates through `plio/cache.py`
+- [ ] Any manual schema switch restores the original schema afterwards
+
+## Debug
+- "Missing" data → print `connection.schema_name` at the failure point; 9 times out of 10 you're on the wrong schema
+- Stale entity after update → grep the mutation path for a missing invalidate call
+- Works in tests, breaks live → tests may run on the default tenant only; add an org-tenant test case
+
+## Update Scaffold
+- [ ] Update `.mex/ROUTER.md` "Current Project State" if what's working/not built has changed
+- [ ] Update any `.mex/context/` files that are now out of date
+- [ ] If this is a new task type without a pattern, create one in `.mex/patterns/` and add to `INDEX.md`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+---
+name: agents
+description: Always-loaded project anchor. Read this first. Contains project identity, non-negotiables, commands, and pointer to ROUTER.md for full context.
+last_updated: 2026-07-11
+---
+
+# Plio Backend
+
+## What This Is
+Multi-tenant Django REST API powering Plio — interactive video lessons: creators build plios (video + timed questions), learners watch and answer; every workspace is an isolated Postgres schema.
+
+## Non-Negotiables
+- Respect tenancy on every data access — the `Organization` request header selects the Postgres schema (django-tenants); never query across schemas without an explicit schema switch
+- Deletes are soft deletes (django-safedelete) everywhere — never hard-delete rows or write raw SQL deletes
+- Invalidate the Redis cache through the helpers in `plio/cache.py` whenever a cached entity mutates — keys are tenant-scoped
+- Never commit secrets — `.env` is gitignored; document new vars in `.env.example` and `docs/ENV.md`
+- Never edit an applied migration; new models must be placed correctly in SHARED_APPS vs TENANT_APPS in `plio/settings.py`
+
+## Commands
+- Run (docker): `docker-compose up -d --build` — API at http://0.0.0.0:8001/api/v1, admin at /admin
+- Test: `docker-compose exec web python manage.py test` (CI runs `coverage run manage.py test`)
+- Lint: `pre-commit run --all-files` (black + flake8)
+- Migrations: `docker-compose exec web python manage.py makemigrations` / `migrate`
+
+## After Every Task
+After meaningful work, run GROW:
+- Ground: what changed in reality?
+- Record: update `.mex/ROUTER.md` and relevant `.mex/context/` files
+- Orient: create or update a `.mex/patterns/` runbook if this can recur
+- Write: bump `last_updated` on changed scaffold files and run `mex log` when rationale matters
+
+## Navigation
+At the start of every session, read `.mex/ROUTER.md` before doing anything else.
+For full project context, patterns, and task guidance — everything is there.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## What

Sets up [mex](https://github.com/mex-memory/mex) — persistent, drift-checked project memory for AI coding agents — on this repo.

- **Root `AGENTS.md`** — small always-loaded anchor (project identity, non-negotiables, commands) read by Codex; **`CLAUDE.md` is a symlink to it** so Claude Code reads the identical config
- **`.mex/ROUTER.md`** — session bootstrap: current project state + routing table into context files
- **`.mex/context/`** — architecture (tenant middleware → OAuth → DRF → Redis cache flow), stack, conventions, decisions, setup
- **`.mex/patterns/`** — runbooks: add-api-endpoint, tenancy-and-caching, run-tests-and-migrations

Notably, the scaffold documents that master runs Django 3.1.1 with the stepwise migration chain to 5.2.14 LTS pending in #354–#360, so agents don't reach for newer Django APIs on master.

## Why

Gives any AI agent session durable, navigable context instead of a cold start, and keeps that context honest: `npx mex-agent check` validates paths, commands, and claims against the real codebase with zero tokens.

## Verification

`npx mex-agent check` → **drift score 100/100** (0 errors, 0 warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)